### PR TITLE
Sample of app-domain isolation for .NET activity

### DIFF
--- a/Samples/CrossAppDomainDotNetActivitySample/CrossAppDomainDotNetActivity.cs
+++ b/Samples/CrossAppDomainDotNetActivitySample/CrossAppDomainDotNetActivity.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
+
+using Microsoft.Azure.Management.DataFactories.Models;
+using Microsoft.Azure.Management.DataFactories.Runtime;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CrossAppDomainDotNetActivitySample
+{
+    public abstract class CrossAppDomainDotNetActivity<TExecutionContext>
+        : MarshalByRefObject, IActivityLogger, ICrossAppDomainDotNetActivity<TExecutionContext>, IDotNetActivity
+        where TExecutionContext : class
+    {
+        IActivityLogger logger;
+
+        IDictionary<string, string> IDotNetActivity.Execute(IEnumerable<LinkedService> linkedServices,
+            IEnumerable<Dataset> datasets, Activity activity, IActivityLogger logger)
+        {
+            TExecutionContext context = this.PreExecute(linkedServices, datasets, activity, logger);
+
+            Type myType = this.GetType();
+            var assemblyLocation = new FileInfo(myType.Assembly.Location);
+            var appDomainSetup = new AppDomainSetup
+            {
+                ApplicationBase = assemblyLocation.DirectoryName,
+                ConfigurationFile = assemblyLocation.Name + ".config"
+            };
+            AppDomain appDomain = AppDomain.CreateDomain(myType.ToString(), null, appDomainSetup);
+            var proxy = (ICrossAppDomainDotNetActivity<TExecutionContext>)
+                appDomain.CreateInstanceAndUnwrap(myType.Assembly.FullName, myType.FullName);
+            this.logger = logger;
+            return proxy.Execute(context, (IActivityLogger)this);
+        }
+
+        public abstract IDictionary<string, string> Execute(TExecutionContext context, IActivityLogger logger);
+
+        public override object InitializeLifetimeService()
+        {
+            // Ensure that the client-activated object lives as long as the hosting app domain.
+            return null;
+        }
+
+        protected virtual TExecutionContext PreExecute(IEnumerable<LinkedService> linkedServices,
+            IEnumerable<Dataset> datasets, Activity activity, IActivityLogger logger)
+        {
+            return null;
+        }
+
+        void IActivityLogger.Write(string format, params object[] args)
+        {
+            this.logger.Write(format, args);
+        }
+    }
+}

--- a/Samples/CrossAppDomainDotNetActivitySample/CrossAppDomainDotNetActivitySample.csproj
+++ b/Samples/CrossAppDomainDotNetActivitySample/CrossAppDomainDotNetActivitySample.csproj
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D0E2D690-743F-4F18-A1C4-8DCF1BA256B8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CrossAppDomainDotNetActivitySample</RootNamespace>
+    <AssemblyName>CrossAppDomainDotNetActivitySample</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Common, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Common.2.0.4\lib\net45\Microsoft.Azure.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Common.2.0.4\lib\net45\Microsoft.Azure.Common.NetFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Management.DataFactories, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Management.DataFactories.4.5.0\lib\net45\Microsoft.Azure.Management.DataFactories.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.6.2.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CrossAppDomainDotNetActivity.cs" />
+    <Compile Include="ICrossAppDomainDotNetActivity.cs" />
+    <Compile Include="MyDotNetActivity.cs" />
+    <Compile Include="MyDotNetActivityContext.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Samples/CrossAppDomainDotNetActivitySample/ICrossAppDomainDotNetActivity.cs
+++ b/Samples/CrossAppDomainDotNetActivitySample/ICrossAppDomainDotNetActivity.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
+
+using Microsoft.Azure.Management.DataFactories.Runtime;
+using System.Collections.Generic;
+
+namespace CrossAppDomainDotNetActivitySample
+{
+    interface ICrossAppDomainDotNetActivity<TExecutionContext>
+    {
+        IDictionary<string, string> Execute(TExecutionContext context, IActivityLogger logger);
+    }
+}

--- a/Samples/CrossAppDomainDotNetActivitySample/MyDotNetActivity.cs
+++ b/Samples/CrossAppDomainDotNetActivitySample/MyDotNetActivity.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
+
+using Microsoft.Azure.Management.DataFactories.Models;
+using Microsoft.Azure.Management.DataFactories.Runtime;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CrossAppDomainDotNetActivitySample
+{
+    // NOTE: This is a *toy* implementation of CrossAppDomainDotNetActivity.  Proper error handling has been elided 
+    // for brevity's sake.  A production implementation should include proper error handling.
+    class MyDotNetActivity : CrossAppDomainDotNetActivity<MyDotNetActivityContext>
+    {
+        protected override MyDotNetActivityContext PreExecute(IEnumerable<LinkedService> linkedServices,
+            IEnumerable<Dataset> datasets, Activity activity, IActivityLogger logger)
+        {
+            WriteGreeting(logger);
+            // Process ADF artifacts up front as these objects are not serializable across app domain boundaries.
+            Dataset dataset = datasets.First(ds => ds.Name == activity.Inputs.Single().Name);
+            var blobProperties = (AzureBlobDataset)dataset.Properties.TypeProperties;
+            LinkedService linkedService = linkedServices.First(ls => ls.Name == dataset.Properties.LinkedServiceName);
+            var storageProperties = (AzureStorageLinkedService)linkedService.Properties.TypeProperties;
+            return new MyDotNetActivityContext
+            {
+                ConnectionString = storageProperties.ConnectionString,
+                FolderPath = blobProperties.FolderPath,
+                FileName = blobProperties.FileName
+            };
+        }
+
+        public override IDictionary<string, string> Execute(MyDotNetActivityContext context, IActivityLogger logger)
+        {
+            WriteGreeting(logger);
+            // This demonstrates using a type (i.e., CloudBlob) available in Azure storage 6.2 but not 4.3.
+            CloudStorageAccount account = CloudStorageAccount.Parse(context.ConnectionString);
+            var blob = new CloudBlob(
+                new Uri(new Uri(account.BlobEndpoint, context.FolderPath), context.FileName), account.Credentials);
+            string message = string.Format("The blob's type is '{0}' and it does{1} exist.",
+                blob.BlobType, blob.Exists() ? "" : "n't");
+            logger.Write(message);
+            return new Dictionary<string, string>() { { "Message", message } };
+        }
+
+        static void WriteGreeting(IActivityLogger logger)
+        {
+            // This demonstrates in which app domain the caller is running.
+            logger.Write("Hello, world, from app domain '{0}'!", AppDomain.CurrentDomain.FriendlyName);
+        }
+    }
+}

--- a/Samples/CrossAppDomainDotNetActivitySample/MyDotNetActivityContext.cs
+++ b/Samples/CrossAppDomainDotNetActivitySample/MyDotNetActivityContext.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
+
+using System;
+
+namespace CrossAppDomainDotNetActivitySample
+{
+    [Serializable]
+    class MyDotNetActivityContext
+    {
+        public string ConnectionString { get; set; }
+        public string FolderPath { get; set; }
+        public string FileName { get; set; }
+    }
+}

--- a/Samples/CrossAppDomainDotNetActivitySample/Properties/AssemblyInfo.cs
+++ b/Samples/CrossAppDomainDotNetActivitySample/Properties/AssemblyInfo.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All Rights Reserved.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CrossAppDomainDotNetActivitySample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CrossAppDomainDotNetActivitySample")]
+[assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All Rights Reserved.")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("864d9a5e-fe51-4f98-8abb-191158cc7816")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Samples/CrossAppDomainDotNetActivitySample/README.md
+++ b/Samples/CrossAppDomainDotNetActivitySample/README.md
@@ -1,0 +1,7 @@
+# Sample of app-domain isolation for .NET activity
+
+This sample allows you to author a custom .NET activity for ADF that is not constrained to assembly versions used by the ADF launcher (e.g., WindowsAzure.Storage v4.3.0, Newtonsoft.Json v6.0.x, etc.).
+
+The code includes an abstract base class (CrossAppDomainDotNetActivity) that implements app-domain isolation and a sample derived class (MyDotNetActivity) that demonstrates using WindowsAzure.Storage v6.2.0.
+
+Note: The public types exposed by the ADF SDK are not serializable across app domain boundaries. As such, the derived class must provide pre-execution logic (PreExecute) to process the ADF objects into a serializable object that is then passed to the core logic (ExecuteCore).

--- a/Samples/CrossAppDomainDotNetActivitySample/packages.config
+++ b/Samples/CrossAppDomainDotNetActivitySample/packages.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Hyak.Common" version="1.0.2" targetFramework="net45" />
+  <package id="Microsoft.Azure.Common" version="2.0.4" targetFramework="net45" />
+  <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataFactories" version="4.5.0" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="6.2.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This commit includes a sample that uses app-domain isolation to allow a
.NET activity to fully control versions of its dependencies.

- A base class, CrossAppDomainDotNetActivity that launches the core
custom execution logic in a separate app domain.
- A derived class, MyDotNetActivity, that demonstrates use of a
different version (v6.2.0) of the Azure storage library than the one
(v4.3.0) loaded by the launcher.