### PR TITLE
Spark ADF Add Extra Files options

### DIFF
--- a/Samples/Spark/Spark-ADF/src/main/java/com/adf/spark/SparkJob.java
+++ b/Samples/Spark/Spark-ADF/src/main/java/com/adf/spark/SparkJob.java
@@ -172,9 +172,7 @@ public class SparkJob extends Configured implements Tool {
     private static String[] filterArgs(String[]args){
         List<String> filteredArgs = new ArrayList<String>();
         for(String a:args){
-            //if(a.contains("=")){
                 filteredArgs.add(a);
-            //}
         }
        return filteredArgs.toArray(new String[]{});
     }


### PR DESCRIPTION
Adds extra files options to the MapReduce job to launch a Spark Job, using the addJar().

Also removes a hardcoded check of "=" for arguments that prevents extra arguments being passed to the spark launcher, such as property files or configuration files required by the Spark Job.