### PR TITLE
SFTP MetaData Reader

### DIFF
--- a/SamplesV2/SFTPLatestMetaDataReader/ADF_SFTP_MetadataReader.cs
+++ b/SamplesV2/SFTPLatestMetaDataReader/ADF_SFTP_MetadataReader.cs
@@ -1,0 +1,118 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Data;
+using System.IO;
+using Renci.SshNet;
+using System.Linq;
+using System.Data.SqlClient;
+
+namespace CustomActivities
+{
+    class ADF_SFTP_MetadataReader : IClass
+    {
+        static string sftpUserName;
+        static string passWord;
+        static string connectionHost;
+        static string outPutTableName;
+        static string outPutDbConnectionString;
+        static string fileName;
+        static string FileCat;
+        static string FileExt;
+        static string remoteDirectory;
+
+        public void Execute()
+        {
+            dynamic activity = JsonConvert.DeserializeObject(File.ReadAllText("activity.json"));
+
+            connectionHost = activity.typeProperties.extendedProperties.connectionHost;
+            outPutTableName = activity.typeProperties.extendedProperties.outPutTableName;
+            outPutDbConnectionString = activity.typeProperties.extendedProperties.outPutDbConnectionString;
+            sftpUserName = activity.typeProperties.extendedProperties.sftpUserName;
+            remoteDirectory = activity.typeProperties.extendedProperties.remoteDirectory;
+            passWord = activity.typeProperties.extendedProperties.passWord;
+            FileCat = activity.typeProperties.extendedProperties.FileCat;
+            FileExt = activity.typeProperties.extendedProperties.FileExt;
+
+            try
+            {
+
+                DataTable tempDataTable = SFTPMetadata(connectionHost, sftpUserName, passWord, remoteDirectory);
+
+                SQLCopy(outPutDbConnectionString, tempDataTable, outPutTableName);
+
+            }
+            catch (Exception ex)
+            {
+
+                throw;
+            }
+
+        }
+
+
+        public static DataTable SFTPMetadata(string connectionHost, string connectionUsername, string connectionPassword, string remoteDirectory)
+        {
+
+
+            using (var sftp = new SftpClient(connectionHost, connectionUsername, connectionPassword))
+            {
+                sftp.Connect();
+
+                var files = sftp.ListDirectory(remoteDirectory);
+
+                var file = files.Where(y => !y.Name.StartsWith(".")).OrderBy(x => x.LastAccessTime).Last();
+
+                DataTable table = new DataTable();
+
+                table.Columns.Add("FileType", typeof(string));
+
+                table.Columns.Add("Source", typeof(string));
+
+                table.Columns.Add("FileName", typeof(string));
+
+                table.Columns.Add("DateTimeUTC", typeof(DateTime));
+
+                Console.WriteLine("Last updated file :" + file.Name);
+
+                fileName = file.Name;
+
+                table.Rows.Add(FileExt, FileCat, fileName, DateTime.UtcNow);
+                return table;
+            }
+
+
+        }
+
+
+        public static void SQLCopy(string outPutDbConnectionString, DataTable tempDataTable, string DBTableName)
+        {
+            try
+            {
+                SqlConnection dbConnection = new SqlConnection(outPutDbConnectionString);
+
+                dbConnection.Open();
+
+                SqlBulkCopy bulkcopy = new SqlBulkCopy(dbConnection);
+                bulkcopy.DestinationTableName = DBTableName;
+                bulkcopy.BatchSize = 100;
+                bulkcopy.BulkCopyTimeout = 1000;
+                bulkcopy.WriteToServer(tempDataTable);
+                dbConnection.Close();
+
+            }
+            catch (Exception ex)
+
+            {
+
+                throw;
+            }
+
+
+        }
+
+
+
+
+    }
+
+}

--- a/SamplesV2/SFTPLatestMetaDataReader/ClassFactory.cs
+++ b/SamplesV2/SFTPLatestMetaDataReader/ClassFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace CustomActivities
+{
+    internal class ClassFactory
+    {
+             public IClass GetClass(string type)
+        {
+
+            //Get the namespace
+            var assembly = Assembly.GetExecutingAssembly();
+
+            //Get all the class types in the namespace and only select the matching class type
+            var objectType = assembly.GetTypes().First(t => t.Name == type);
+
+            //Create an instance of that class type
+            var obj = Activator.CreateInstance(objectType);
+
+            //Cast the created instance
+            return (IClass)obj;
+        }
+    }
+}

--- a/SamplesV2/SFTPLatestMetaDataReader/CustomActivities.csproj
+++ b/SamplesV2/SFTPLatestMetaDataReader/CustomActivities.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Renci.SshNet.Async" Version="1.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+  </ItemGroup>
+
+</Project>

--- a/SamplesV2/SFTPLatestMetaDataReader/IClass.cs
+++ b/SamplesV2/SFTPLatestMetaDataReader/IClass.cs
@@ -1,0 +1,7 @@
+﻿namespace CustomActivities
+{
+    interface IClass
+    {
+         void Execute();
+    }
+}

--- a/SamplesV2/SFTPLatestMetaDataReader/Program.cs
+++ b/SamplesV2/SFTPLatestMetaDataReader/Program.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace CustomActivities
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var classCreator = new ClassFactory();
+
+            string result = "ADF_SFTP_MetadataReader";//Console.ReadLine();
+
+
+            try
+            {
+                IClass cl = classCreator.GetClass(args[0]);
+                cl.Execute();
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+
+        }
+    }
+}

--- a/SamplesV2/SFTPLatestMetaDataReader/activity.json
+++ b/SamplesV2/SFTPLatestMetaDataReader/activity.json
@@ -1,0 +1,16 @@
+{
+                "typeProperties": {
+                   
+					"extendedProperties": {
+                        "outPutTableName": "FileReader_MetaData",
+                        "outPutDbConnectionString": "Data Source=[yourdbserver].database.windows.net;Initial Catalog=[yourdb];User ID=[username];Password=[pwd];Connection Timeout=500",
+                        "connectionHost": "[yoursftp].com",
+                        "sftpUserName": "$$$$$$",
+                        "passWord": "$$$$$$$",
+                        "remoteDirectory": "/###/####/",
+                        "FileCat": "SLFWD-CI",
+                        "FileExt": ".txt"
+                    }
+			  }
+           }    
+           

--- a/SamplesV2/SFTPLatestMetaDataReader/tablescript.sql
+++ b/SamplesV2/SFTPLatestMetaDataReader/tablescript.sql
@@ -1,0 +1,8 @@
+CREATE TABLE [dbo].[FileReader_MetaData](
+	[FileType] [varchar](100) NULL,
+	[Source] [varchar](100) NULL,
+	[FileName] [varchar](100) NULL,
+	[DateTimeUTC] [datetime] NULL
+) ON [PRIMARY]
+GO
+


### PR DESCRIPTION
ADFv2 off-the shelf metadata activity cannot capture the latest delivered files metadata on an SFTP host.
As a workaround for that this custom code can be used. This will capture metadata into an AzureSQLDB which can be looked up using a lookup activity
