### PR TITLE
FixBoolJsonParseErrorInPrePostDeploymentScript.V2

### DIFF
--- a/SamplesV2/ContinuousIntegrationAndDelivery/PrePostDeploymentScript.Ver2.ps1
+++ b/SamplesV2/ContinuousIntegrationAndDelivery/PrePostDeploymentScript.Ver2.ps1
@@ -472,7 +472,7 @@ function Update-TriggerTemplate {
                 $parameterValue = ConvertTo-Json $templateParameters.$($parameterName).value
                 $templateJson = $templateJson -replace [System.Text.RegularExpressions.Regex]::Escape("`"$($parameterMatch.Value)`""), $parameterValue
             } elseif ($parameterType -eq 'Boolean' -or $parameterType -eq 'Int64') {
-                $templateJson = $templateJson -replace [System.Text.RegularExpressions.Regex]::Escape("`"$($parameterMatch.Value)`""), $templateParameters.$($parameterName).value
+                $templateJson = $templateJson -replace [System.Text.RegularExpressions.Regex]::Escape("`"$($parameterMatch.Value)`""), $templateParameters.$($parameterName).value.ToString().ToLower()
             } else {
                 $templateJson = $templateJson -replace [System.Text.RegularExpressions.Regex]::Escape($parameterMatch.Value), $templateParameters.$($parameterName).value
             }


### PR DESCRIPTION
There is an issue with the current script where as of 3 days ago the code changed and there is Regex that is converting the value of Boolean to start with a capital letter.  For example DevOpsFileEvent_properties_typeProperties_ignoreEmptyBlobs it was converting that to value True with a capital T which results in error ##[error] Conversion from JSON failed with error: Unexpected character encountered while parsing value: T. Path 'properties.typeProperties.ignoreEmptyBlobs', line 21, position 26. from Line: 680 ##[error]Conversion from JSON failed with error: Unexpected character encountered while parsing value: T. Path 'properties.typeProperties.ignoreEmptyBlobs', line 21, position 26. To fix this you add the .ToString().ToLower() to the end of line 475.  Which will not convert boolean values to capital letters and makes the error go away.