### PR TITLE
Skip comparing parameter values that are both null (#540)

### DIFF
--- a/SamplesV2/ContinuousIntegrationAndDelivery/PrePostDeploymentScript.Ver2.ps1
+++ b/SamplesV2/ContinuousIntegrationAndDelivery/PrePostDeploymentScript.Ver2.ps1
@@ -425,7 +425,12 @@ function Compare-TriggerPipelineReference {
                                 Write-Host "##[warning] SecureString parameter is always treated as a change"
                                 break
                             } else {
-                                $paramValueChanges = Compare-Object -ReferenceObject ($deployedValue.ToString() | ConvertFrom-Json) -DifferenceObject ($payloadValue.ToString() | ConvertFrom-Json)
+                                $deployedValueObj = ConvertFrom-Json $deployedValue.ToString()
+                                $payloadValueObj = ConvertFrom-Json $payloadValue.ToString()
+                                # when both are null, do not compare them
+                                if ($null -ne $deployedValueObj -and $null -ne $payloadValueObj) {
+                                    $paramValueChanges = Compare-Object -ReferenceObject $deployedValueObj -DifferenceObject $payloadValueObj
+                                }
                             }
                         } elseif ($deployedValue.GetType().Name -eq "Boolean") {
                             $paramValueChanges = Compare-Object -ReferenceObject ($deployedValue.ToString().ToLower() | ConvertFrom-Json) -DifferenceObject ($payloadValue.ToString().ToLower() | ConvertFrom-Json)


### PR DESCRIPTION
Due to the nature that "[]" evaluates to `$null` when passed into `ConvertFrom-Json`, `Compare-Object` throws an error that the ReferenceObject cannot be null.

This change first compares the deployedObject and payloadObject if both are non-null and only then passes the two object to `Compare-Object`.
If one of the objects is null and the other is not, it will still throw an error, but the script will still stop the triggers as before which is good in this case (null != non-null).

For more details, see #540 