### PR TITLE
Fix for factory update resetting github repoConfig

### DIFF
--- a/SamplesV2/ContinuousIntegrationAndDelivery/GlobalParametersUpdateScript.ps1
+++ b/SamplesV2/ContinuousIntegrationAndDelivery/GlobalParametersUpdateScript.ps1
@@ -9,14 +9,14 @@ Import-Module Az.DataFactory
 
 $newGlobalParameters = New-Object 'system.collections.generic.dictionary[string,Microsoft.Azure.Management.DataFactory.Models.GlobalParameterSpecification]'
 
+Write-Warning "This method of deploying global parameters using PS script is not recommended. Please use the new mechanism as per this document https://learn.microsoft.com/en-us/azure/data-factory/author-global-parameters#cicd"
+
 Write-Host "Getting global parameters JSON from: " $globalParametersFilePath
 $globalParametersJson = Get-Content $globalParametersFilePath
 
 Write-Host "Parsing JSON..."
 $globalParametersObject = [Newtonsoft.Json.Linq.JObject]::Parse($globalParametersJson)
 
-# $gp in $factoryFileObject.properties.globalParameters.GetEnumerator()) 
-# may  be used in case you use non-standard location for global parameters. It is not recommended. 
 foreach ($gp in $globalParametersObject.GetEnumerator()) {
     Write-Host "Adding global parameter:" $gp.Key
     $globalParameterValue = $gp.Value.ToObject([Microsoft.Azure.Management.DataFactory.Models.GlobalParameterSpecification])
@@ -27,5 +27,9 @@ $dataFactory = Get-AzDataFactoryV2 -ResourceGroupName $resourceGroupName -Name $
 $dataFactory.GlobalParameters = $newGlobalParameters
 
 Write-Host "Updating" $newGlobalParameters.Count "global parameters."
+
+if ($dataFactory.RepoConfiguration -and ($dataFactory.RepoConfiguration.GetType().Name -eq 'FactoryGitHubConfiguration') -and (-not $dataFactory.RepoConfiguration.HostName)) { 
+        $dataFactory.RepoConfiguration.HostName = 'https://github.com' 
+}
 
 Set-AzDataFactoryV2 -InputObject $dataFactory -Force


### PR DESCRIPTION
The PS command Set-AzDataFactoryV2 fails to persist the repoConfiguration if GitHub configuration doesn't have hostName property.
The PS SDK expects hostName for GitHub repo type so using the default https://github.com/ for hostName.