### PR TITLE
Refactor `Push-PipelinesToList` to handle null dependencies

### DIFF
--- a/SamplesV2/ContinuousIntegrationAndDelivery/PrePostDeploymentScript.Ver2.ps1
+++ b/SamplesV2/ContinuousIntegrationAndDelivery/PrePostDeploymentScript.Ver2.ps1
@@ -79,8 +79,15 @@ function Push-PipelinesToList {
         return;
     }
     $visited[$pipeline.Name] = $true;
-    $pipeline.Activities | ForEach-Object { Get-PipelineDependency -activity $_ -pipelineNameResourceDict $pipelineNameResourceDict }  | ForEach-Object {
-        Push-PipelinesToList -pipeline $pipelineNameResourceDict[$_] -pipelineNameResourceDict $pipelineNameResourceDict -visited $visited -sortedList $sortedList
+    foreach ($activity in $pipeline.Activities) { 
+        $activityName = $activity.Name
+        Get-PipelineDependency -activity $activity -pipelineNameResourceDict $pipelineNameResourceDict 
+    } foreach ($dependency in $dependecies) {
+        if ($null -eq $dependency) {
+            Write-Warning "Warning: Pipeline dependency is null for pipeline $($pipeline.Name) and activity $activityName. The activity $activityName is missing an invoked pipeline reference."
+        } else {
+            Push-PipelinesToList -pipeline $pipelineNameResourceDict[$dependency] -pipelineNameResourceDict $pipelineNameResourceDict -visited $visited -sortedList $sortedList
+        }
     }
     $sortedList.Push($pipeline)
 }


### PR DESCRIPTION
Refactor the `Push-PipelinesToList` function in `PrePostDeploymentScript.Ver2.ps1` to improve pipeline dependency handling. 
If a dependency is null, display a warning message identifying which pipeline and activity should be modified. Before the fix, the deployment pipeline would fail without giving any good error message. 

Cases where dependency is null -> When one has an execute pipeline in the ADF, that references a pipeline that has been deleted, the activity is set to null. At the moment this does not show up as an error in the 'Validate' step in ADF (as I would expect it would)

Alternative fix: consider throwing an error with the same message, instead of just writing a warning ?

Resolves #679, resolves #678, resolves #675, resolves #431 